### PR TITLE
adds skipPrettier and self closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can also disable the conversion of the built-in components `{{link-to}}`, `{
 }
 ```
 
-You can also disable the final **Prettier** formatting and attempt to preserve white space by adding `skipPrettier` as follows:
+You can also disable the final **Prettier** formatting by adding `skipPrettier` as follows:
 
 **config/anglebrackets-codemod-config.json**
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ You can also disable the conversion of the built-in components `{{link-to}}`, `{
 }
 ```
 
+You can also disable the final **Prettier** formatting and attempt to preserve white space by adding `skipPrettier` as follows:
+
+**config/anglebrackets-codemod-config.json**
+
+```js
+{
+  "helpers": [],
+  "skipPrettier": true
+}
+```
+
 You can execute the codemod with custom configuration by specifying a `--config` command line option as follows:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ You can also disable the final **Prettier** formatting and attempt to preserve w
   "skipPrettier": true
 }
 ```
+By disabling Prettier, oddly formatted `hbs` files will remain (somewhat) unchanged:
+
+#### From
+```hbs
+{{#bs-button-group
+  value=buttonGroupValue
+  type="checkbox"
+  onChange=(action (mut buttonGroupValue)) as |bg|}}
+			{{#bg.button value=1}}1{{/bg.button}}
+  {{#bg.button value=2}}2{{/bg.button}}
+  			{{#bg.button value=3}}3{{/bg.button}}
+				{{#bg.button value=3}}3{{/bg.button}}
+{{/bs-button-group}}
+```
+
+#### To
+```hbs
+<BsButtonGroup @value={{buttonGroupValue}} @type="checkbox" @onChange={{action (mut buttonGroupValue)}} as |bg|>
+			<bg.button @value={{1}}>1</bg.button>
+  <bg.button @value={{2}}>2</bg.button>
+  			<bg.button @value={{3}}>3</bg.button>
+				<bg.button @value={{3}}>3</bg.button>
+</BsButtonGroup>
+```
 
 You can execute the codemod with custom configuration by specifying a `--config` command line option as follows:
 
@@ -95,6 +119,7 @@ $ cd my-ember-app-or-addon
 $ npx ember-angle-brackets-codemod angle-brackets app/templates --config ./config/anglebrackets-codemod-config.json
 ```
 
+### Getting a list of helpers
 To get a list of helpers in your app you can do this in the Developer Console in your browser inside of your app:
 ```js
 var componentLikeHelpers = Object.keys(require.entries)

--- a/transforms/angle-brackets/__testfixtures__/custom-options.config.json
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.config.json
@@ -1,4 +1,5 @@
 {
   "helpers": ["some-helper1", "some-helper2", "some-helper3"],
-  "skipBuiltInComponents": true
+  "skipBuiltInComponents": true,
+  "skipPrettier": true
 }

--- a/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
@@ -21,3 +21,9 @@
   			{{#bg.button value=3}}3{{/bg.button}}
 				{{#bg.button value=3}}3{{/bg.button}}
 {{/bs-button-group}}
+
+someFunction({
+  {{#unless installationIsAnonymous}}
+    console.log("hi");
+  {{/unless}}
+});

--- a/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
@@ -4,3 +4,20 @@
 {{link-to "Title" "some.route"}}
 {{textarea value=this.model.body}}
 {{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}
+
+{{site-header user=this.user class=(if this.user.isAdmin "admin")}}
+{{#super-select selected=this.user.country as |s|}}
+  {{#each this.availableCountries as |country|}}
+    {{#s.option value=country}}{{country.name}}{{/s.option}}
+  {{/each}}
+{{/super-select}}
+
+{{#bs-button-group
+  value=buttonGroupValue
+  type="checkbox"
+  onChange=(action (mut buttonGroupValue)) as |bg|}}
+			{{#bg.button value=1}}1{{/bg.button}}
+  {{#bg.button value=2}}2{{/bg.button}}
+  			{{#bg.button value=3}}3{{/bg.button}}
+				{{#bg.button value=3}}3{{/bg.button}}
+{{/bs-button-group}}

--- a/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
@@ -18,3 +18,9 @@
   			<bg.button @value={{3}}>3</bg.button>
 				<bg.button @value={{3}}>3</bg.button>
 </BsButtonGroup>
+
+someFunction({
+  {{#unless installationIsAnonymous}}
+    console.log("hi");
+  {{/unless}}
+});

--- a/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
@@ -4,3 +4,17 @@
 {{link-to "Title" "some.route"}}
 {{textarea value=this.model.body}}
 {{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}
+
+<SiteHeader @user={{this.user}} class={{if this.user.isAdmin "admin"}} />
+<SuperSelect @selected={{this.user.country}} as |s|>
+  {{#each this.availableCountries as |country|}}
+    <s.option @value={{country}}>{{country.name}}</s.option>
+  {{/each}}
+</SuperSelect>
+
+<BsButtonGroup @value={{buttonGroupValue}} @type="checkbox" @onChange={{action (mut buttonGroupValue)}} as |bg|>
+			<bg.button @value={{1}}>1</bg.button>
+  <bg.button @value={{2}}>2</bg.button>
+  			<bg.button @value={{3}}>3</bg.button>
+				<bg.button @value={{3}}>3</bg.button>
+</BsButtonGroup>

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -352,8 +352,12 @@ module.exports = function(fileInfo, api, options) {
     let attributes;
     let children = node.program ? node.program.body : undefined;
     let blockParams = node.program ? node.program.blockParams : undefined;
+    let selfClosing = node.type !== 'BlockStatement';
 
     if (tagName === 'link-to') {
+      
+      selfClosing = false;
+      
       if (node.type === 'MustacheStatement') {
         let params = node.params;
         let textParam = params.shift(); //the first param becomes the block content
@@ -373,11 +377,6 @@ module.exports = function(fileInfo, api, options) {
       }
 
       attributes = transformNodeAttributes(node);
-    }
-
-    let selfClosing = node.type !== 'BlockStatement';
-    if ( newTagName === 'LinkTo') {
-      selfClosing = false;
     }
 
     return b.element({ name: newTagName, selfClosing }, {

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -408,7 +408,6 @@ module.exports = function(fileInfo, api, options) {
           a.value = b.text(_EMPTY_STRING_);
         }
       });
-      // console.log(node.selfClosing, node.tag);
     }
   });
 

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -374,7 +374,7 @@ module.exports = function(fileInfo, api, options) {
 
       attributes = transformNodeAttributes(node);
     }
-    // console.log('selfClosing: ', node)
+
     let selfClosing = node.type !== 'BlockStatement';
     if ( newTagName === 'LinkTo') {
       selfClosing = false;


### PR DESCRIPTION
Disables Prettier completely. An alternative way to format the output of the codemod where in most cases "white space" is preserved.  Uses the latest `glimmer/syntax` to apply selfClosing tags when an element is not in block form.