### PR TITLE
Assume reserved words are local vars when arg equal to 0

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/reserved.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/reserved.input.hbs
@@ -1,0 +1,3 @@
+{{some-component foo=action}}
+{{some-component foo=t}}
+{{some-component foo=component}}

--- a/transforms/angle-brackets/__testfixtures__/reserved.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/reserved.output.hbs
@@ -1,0 +1,3 @@
+<SomeComponent @foo={{this.action}} />
+<SomeComponent @foo={{this.t}} />
+<SomeComponent @foo={{this.component}} />

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -309,6 +309,12 @@ module.exports = function(fileInfo, api, options) {
         _value = b.text(a.value.original || _EMPTY_STRING_);
       }
 
+      //Check if properties match popular/reserved words and have 0 args
+      if ( _value.path && _value.path.original && IGNORE_MUSTACHE_STATEMENTS.includes(_value.path.original) && _value.hash.pairs.length === 0) {
+        _value = b.mustache(`this.${_value.path.original}`);
+      }
+
+
       return b.attr(_key, _value);
     });
   };


### PR DESCRIPTION
resolves #88 

Assumption here is that any helper requires some input params (args).  If this is not the case, we again assume this might be a locally scoped property.  Therefore we apply `this` to the front as to not invoke a helper with `{{ }}`