### PR TITLE
[CHORE] Remove rajasegar:author references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Rajasegar Chandran
+Copyright (c) 2019 ember-codemods
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ember-angle-brackets-codemod
 
-[![Build Status](https://travis-ci.org/rajasegar/ember-angle-brackets-codemod.svg?branch=master)](https://travis-ci.org/rajasegar/ember-angle-brackets-codemod) 
-[![Coverage Status](https://coveralls.io/repos/github/rajasegar/ember-angle-brackets-codemod/badge.svg?branch=master)](https://coveralls.io/github/rajasegar/ember-angle-brackets-codemod?branch=master)
+[![Build Status](https://travis-ci.org/ember-codemods/ember-angle-brackets-codemod.svg?branch=master)](https://travis-ci.org/ember-codemods/ember-angle-brackets-codemod) 
+[![Coverage Status](https://coveralls.io/repos/github/ember-codemods/ember-angle-brackets-codemod/badge.svg?branch=master)](https://coveralls.io/github/ember-codemods/ember-angle-brackets-codemod?branch=master)
 [![npm version](http://img.shields.io/npm/v/ember-angle-brackets-codemod.svg?style=flat)](https://npmjs.org/package/ember-angle-brackets-codemod "View this project on npm")
-[![dependencies Status](https://david-dm.org/rajasegar/ember-angle-brackets-codemod/status.svg)](https://david-dm.org/rajasegar/ember-angle-brackets-codemod)
-[![devDependencies Status](https://david-dm.org/rajasegar/ember-angle-brackets-codemod/dev-status.svg)](https://david-dm.org/rajasegar/ember-angle-brackets-codemod?type=dev)
+[![dependencies Status](https://david-dm.org/ember-codemods/ember-angle-brackets-codemod/status.svg)](https://david-dm.org/ember-codemods/ember-angle-brackets-codemod)
+[![devDependencies Status](https://david-dm.org/ember-codemods/ember-angle-brackets-codemod/dev-status.svg)](https://david-dm.org/ember-codemods/ember-angle-brackets-codemod?type=dev)
 
 A [jscodeshift](https://github.com/facebook/jscodeshift) Codemod to convert curly braces syntax to angle brackets syntax for templates
 in an Ember.js app

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rajasegar/ember-angle-brackets-codemod.git"
+    "url": "git+https://github.com/ember-codemods/ember-angle-brackets-codemod.git"
   },
   "keywords": [
     "codemod-cli",
@@ -24,12 +24,12 @@
     "codemods",
     "ember-addon"
   ],
-  "author": "Rajasegar Chandran <rajasegar.c@gmail.com>",
+  "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/rajasegar/ember-angle-brackets-codemod/issues"
+    "url": "https://github.com/ember-codemods/ember-angle-brackets-codemod/issues"
   },
-  "homepage": "https://github.com/rajasegar/ember-angle-brackets-codemod#readme",
+  "homepage": "https://github.com/ember-codemods/ember-angle-brackets-codemod#readme",
   "devDependencies": {
     "coveralls": "^3.0.4",
     "jest": "^24.8.0"

--- a/transforms/-preset.js
+++ b/transforms/-preset.js
@@ -21,7 +21,7 @@ module.exports = function(type) {
         try {
           src = fix(Object.assign({},file, { source: src }), api, options);
         } catch(e) {
-          error = new Error(`Transformation ${fileName} errored on file ${file.path}. Reason ${e}. Please report this in https://github.com/rajasegar/ember-angle-brackets-codemod/issues\n\nStack trace:\n${e.stack}\n\nSource:\n${src}`);
+          error = new Error(`Transformation ${fileName} errored on file ${file.path}. Reason ${e}. Please report this in https://github.com/ember-codemods/ember-angle-brackets-codemod/issues\n\nStack trace:\n${e.stack}\n\nSource:\n${src}`);
         }
 
       });

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -227,8 +227,8 @@ const transformNestedSubExpression = subExpression => {
 const shouldSkipFile = (fileInfo, config) => {
   let source = fileInfo.source;
 
-  if (source.includes("~")) { //skip files with `~` until https://github.com/rajasegar/ember-angle-brackets-codemod/issues/46 is resolved
-    console.warn(`WARNING: ${fileInfo.path} was not converted as it contains a "~" (https://github.com/rajasegar/ember-angle-brackets-codemod/issues/46)`);
+  if (source.includes("~")) { //skip files with `~` until https://github.com/ember-codemods/ember-angle-brackets-codemod/issues/46 is resolved
+    console.warn(`WARNING: ${fileInfo.path} was not converted as it contains a "~" (https://github.com/ember-codemods/ember-angle-brackets-codemod/issues/46)`);
     return true;
   }
 


### PR DESCRIPTION
Since we have transferred the repo to the new org
ember-codemods, removing all the author references
and replacing with ember-codemods

Fixes #91 