### PR TITLE
Use `ember-template-recast` to preserve existing template formatting as much as possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1497,11 +1497,28 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
+    },
+    "async-promise-queue": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.5.tgz",
+      "integrity": "sha512-xi0aQ1rrjPWYmqbwr18rrSKbSaXIeIwSd1J4KAgVfkq8utNbdZoht7GfvfY6swFUAMJ9obkc4WPJmtGwl+B8dw==",
+      "requires": {
+        "async": "^2.4.1",
+        "debug": "^2.6.8"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1855,10 +1872,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
+    },
+    "cli-spinners": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
+      "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ=="
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1875,6 +1896,11 @@
         "strip-ansi": "^5.2.0",
         "wrap-ansi": "^5.1.0"
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "clone-response": {
       "version": "1.0.2",
@@ -2235,6 +2261,14 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "defer-to-connect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
@@ -2355,6 +2389,44 @@
       "version": "1.3.264",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.264.tgz",
       "integrity": "sha512-z8E7WkrrquCuGYv+kKyybuZIbdms+4PeHp7Zm2uIgEhAigP0bOwqXILItwj0YO73o+QyHY/7XtEfP5DsHOWQgQ=="
+    },
+    "ember-template-recast": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-3.1.3.tgz",
+      "integrity": "sha512-su7m2IwxydyZ1bggGvRwKTVgccFoKMFFnPi/Zhmb+xPl5Tcu4i7ykcIbZZnGRNUjpYPaqDDffdKIFcswcRWeHQ==",
+      "requires": {
+        "@glimmer/syntax": "^0.42.0",
+        "async-promise-queue": "^1.0.5",
+        "colors": "^1.3.3",
+        "commander": "^3.0.0",
+        "globby": "^10.0.1",
+        "ora": "^3.4.0",
+        "tmp": "^0.1.0",
+        "workerpool": "^3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "requires": {
+            "rimraf": "^2.6.3"
+          }
+        }
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -4939,6 +5011,14 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5232,6 +5312,11 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -5347,6 +5432,19 @@
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
+      }
+    },
+    "ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
       }
     },
     "os-tmpdir": {
@@ -5551,7 +5649,8 @@
     "prettier": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -5911,7 +6010,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -5920,14 +6018,12 @@
         "mimic-fn": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         },
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
           }
@@ -5952,8 +6048,7 @@
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -6784,6 +6879,14 @@
         "makeerror": "1.0.x"
       }
     },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -6833,6 +6936,16 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "requires": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
+      }
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -31,16 +31,16 @@
     ]
   },
   "dependencies": {
-    "@glimmer/syntax": "^0.42.0",
     "codemod-cli": "^2.0.0",
-    "prettier": "^1.18.2"
+    "ember-template-recast": "^3.1.3"
   },
   "devDependencies": {
     "coveralls": "^3.0.6",
     "eslint": "^6.5.0",
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.1",
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "prettier": "^1.18.2"
   },
   "engines": {
     "node": "^8 || >=10"

--- a/transforms/angle-brackets/test.js
+++ b/transforms/angle-brackets/test.js
@@ -35,6 +35,11 @@ test('actions', () => {
     {{/bs-button-group}}
   `;
 
+  /**
+   * NOTE: An issue has been opened in `ember-template-recast` (https://github.com/ember-template-lint/ember-template-recast/issues/82)
+   * regarding to create an API to allow a transform to customize the whitespace for newly created nodes.
+   *
+   */
   expect(runTest('actions.hbs', input)).toMatchInlineSnapshot(`
     "
         <BsButtonGroup @value={{buttonGroupValue}} @type=\\"checkbox\\" @onChange={{action (mut buttonGroupValue)}} as |bg|>
@@ -79,23 +84,23 @@ test('data-attributes', () => {
     {{x-foo data-test-selector=post.id}}
     {{x-foo label="hi" data-test-selector=true}}
     {{x-foo data-test-foo }}
-    
+
     {{#x-foo data-foo=true}}
       block
     {{/x-foo}}
-    
+
     {{#x-foo data-test-selector=true}}
       block
     {{/x-foo}}
-    
+
     {{#x-foo data-test-selector=post.id}}
       block
     {{/x-foo}}
-    
+
     {{#common/accordion-component data-test-accordion as |accordion|}}
       block
     {{/common/accordion-component}}
-    
+
     {{x-foo
       data-foo
       name="Sophie"
@@ -109,23 +114,23 @@ test('data-attributes', () => {
         <XFoo data-test-selector={{post.id}} />
         <XFoo @label=\\"hi\\" data-test-selector={{true}} />
         <XFoo data-test-foo />
-        
+
         <XFoo data-foo={{true}}>
           block
         </XFoo>
-        
+
         <XFoo data-test-selector={{true}}>
           block
         </XFoo>
-        
+
         <XFoo data-test-selector={{post.id}}>
           block
         </XFoo>
-        
+
         <Common::AccordionComponent data-test-accordion as |accordion|>
           block
         </Common::AccordionComponent>
-        
+
         <XFoo data-foo @name=\\"Sophie\\" />
       "
   `);
@@ -144,8 +149,8 @@ test('deeply-nested-sub', () => {
     {{some-component
       class=(concat foo (some-helper bar quuz))
     }}
-    {{some-component 
-      person=(hash name="Sophie" age=1) 
+    {{some-component
+      person=(hash name="Sophie" age=1)
       message=(t "welcome" count=1)
     }}
     {{some-component
@@ -162,6 +167,11 @@ test('deeply-nested-sub', () => {
     }}
   `;
 
+  /**
+   * NOTE: An issue has been opened in `ember-template-recast` (https://github.com/ember-template-lint/ember-template-recast/issues/82)
+   * regarding to create an API to allow a transform to customize the whitespace for newly created nodes.
+   *
+   */
   expect(runTest('deeply-nested-sub.hbs', input)).toMatchInlineSnapshot(`
     "
         <SomeComponent class={{concat foo (some-helper ted (some-dude bar (a b c)))}}>
@@ -213,48 +223,48 @@ test('entities', () => {
 
 test('html-tags', () => {
   let input = `
-    <input 
+    <input
       type='text'
       value={{userValue}}
       oninput={{action 'change' value='target.value'}}
       class="{{if invalid 'invalid-input'}}"/>
-    
-    <textarea 
+
+    <textarea
       value={{userValue}}
       oninput={{action 'change' value='target.value'}}
       class="{{if invalid 'invalid-input'}}">HI</textarea>
-    
-    <textarea 
+
+    <textarea
       value={{userValue}}
       oninput={{action (action 'change') value='target.value'}}
       class="{{if invalid 'invalid-input'}}">HI</textarea>
-    
+
     <div onclick={{action "clickMe"}}></div>
-    
+
     <div data-foo="{{if someThing yas nah}}"></div>
     <div {{on 'click' this.foo}}></div>
   `;
 
   expect(runTest('html-tags.hbs', input)).toMatchInlineSnapshot(`
     "
-        <input 
+        <input
           type='text'
           value={{userValue}}
           oninput={{action 'change' value='target.value'}}
           class=\\"{{if invalid 'invalid-input'}}\\"/>
-        
-        <textarea 
+
+        <textarea
           value={{userValue}}
           oninput={{action 'change' value='target.value'}}
           class=\\"{{if invalid 'invalid-input'}}\\">HI</textarea>
-        
-        <textarea 
+
+        <textarea
           value={{userValue}}
           oninput={{action (action 'change') value='target.value'}}
           class=\\"{{if invalid 'invalid-input'}}\\">HI</textarea>
-        
+
         <div onclick={{action \\"clickMe\\"}}></div>
-        
+
         <div data-foo=\\"{{if someThing yas nah}}\\"></div>
         <div {{on 'click' this.foo}}></div>
       "
@@ -299,7 +309,7 @@ test('let', () => {
       as |firstName lastName|
     }}
       Welcome back {{concat firstName ' ' lastName}}
-    
+
       Account Details:
       First Name: {{firstName}}
       Last Name: {{lastName}}
@@ -312,7 +322,7 @@ test('let', () => {
           as |firstName lastName|
         }}
           Welcome back {{concat firstName ' ' lastName}}
-        
+
           Account Details:
           First Name: {{firstName}}
           Last Name: {{lastName}}
@@ -354,14 +364,19 @@ test('link-to-inline', () => {
       current-when='apps.segments'
       data-test-segment-link='segments'
     }}
-    {{link-to 
-      segment.name 
-      'apps.app.companies.segments.segment' 
-      segment 
+    {{link-to
+      segment.name
+      'apps.app.companies.segments.segment'
+      segment
       class="t__em-link"
     }}
   `;
 
+  /**
+   * NOTE: An issue has been opened in `ember-template-recast` (https://github.com/ember-template-lint/ember-template-recast/issues/82)
+   * regarding to create an API to allow a transform to customize the whitespace for newly created nodes.
+   *
+   */
   expect(runTest('link-to-inline.hbs', input)).toMatchInlineSnapshot(`
     "
         <LinkTo @route=\\"some.route\\">Title</LinkTo>
@@ -378,7 +393,11 @@ test('link-to-model', () => {
     {{#link-to "post" "string-id"}}Read {{post.title}}...{{/link-to}}
     {{#link-to "post" 557}}Read {{post.title}}...{{/link-to}}
   `;
-
+  /**
+   * NOTE: An issue has been opened in `ember-template-recast` (https://github.com/ember-template-lint/ember-template-recast/issues/82)
+   * regarding to create an API to allow a transform to customize the whitespace for newly created nodes.
+   *
+   */
   expect(runTest('link-to-model.hbs', input)).toMatchInlineSnapshot(`
     "
         <LinkTo @route=\\"post\\" @model={{post}}>Read {{post.title}}...</LinkTo>
@@ -434,7 +453,11 @@ test('link-to-query-param', () => {
       (query-params searchTerm=searchTerm)
     }}
   `;
-
+  /**
+   * NOTE: An issue has been opened in `ember-template-recast` (https://github.com/ember-template-lint/ember-template-recast/issues/82)
+   * regarding to create an API to allow a transform to customize the whitespace for newly created nodes.
+   *
+   */
   expect(runTest('link-to-query-param.hbs', input)).toMatchInlineSnapshot(`
     "
         <LinkTo @route=\\"posts\\" @query={{hash direction=\\"desc\\" showArchived=false}}>

--- a/transforms/angle-brackets/test.js
+++ b/transforms/angle-brackets/test.js
@@ -14,9 +14,11 @@ test('action-params', () => {
   `;
 
   expect(runTest('action-params.hbs', input)).toMatchInlineSnapshot(`
-    "<BsButton @onClick={{action \\"submit\\"}}>
-      Button
-    </BsButton>"
+    "
+        <BsButton @onClick={{action \\"submit\\"}}>
+          Button
+        </BsButton>
+      "
   `);
 });
 
@@ -34,21 +36,13 @@ test('actions', () => {
   `;
 
   expect(runTest('actions.hbs', input)).toMatchInlineSnapshot(`
-    "<BsButtonGroup
-      @value={{buttonGroupValue}}
-      @type=\\"checkbox\\"
-      @onChange={{action (mut buttonGroupValue)}} as |bg|
-    >
-      <bg.button @value={{1}}>
-        1
-      </bg.button>
-      <bg.button @value={{2}}>
-        2
-      </bg.button>
-      <bg.button @value={{3}}>
-        3
-      </bg.button>
-    </BsButtonGroup>"
+    "
+        <BsButtonGroup @value={{buttonGroupValue}} @type=\\"checkbox\\" @onChange={{action (mut buttonGroupValue)}} as |bg|>
+          <bg.button @value={{1}}>1</bg.button>
+          <bg.button @value={{2}}>2</bg.button>
+          <bg.button @value={{3}}>3</bg.button>
+        </BsButtonGroup>
+      "
   `);
 });
 
@@ -57,9 +51,11 @@ test('boolean-values', () => {
     {{my-component prop1=true prop2=false}}
   `;
 
-  expect(runTest('true-values.hbs', input)).toMatchInlineSnapshot(
-    `"<MyComponent @prop1={{true}} @prop2={{false}} />"`
-  );
+  expect(runTest('true-values.hbs', input)).toMatchInlineSnapshot(`
+    "
+        <MyComponent @prop1={{true}} @prop2={{false}} />
+      "
+  `);
 });
 
 test('curly', () => {
@@ -69,12 +65,10 @@ test('curly', () => {
   `;
 
   expect(runTest('curly.hbs', input)).toMatchInlineSnapshot(`
-    "<div>
-      {{foo}}
-    </div>
-    <div>
-      {{{bar}}}
-    </div>"
+    "
+        <div>{{foo}}</div>
+        <div>{{{bar}}}</div>
+      "
   `);
 });
 
@@ -109,24 +103,31 @@ test('data-attributes', () => {
   `;
 
   expect(runTest('data-attributes.hbs', input)).toMatchInlineSnapshot(`
-    "<XFoo data-foo={{true}} />
-    <XFoo data-test-selector={{true}} />
-    <XFoo data-test-selector={{post.id}} />
-    <XFoo @label=\\"hi\\" data-test-selector={{true}} />
-    <XFoo data-test-foo />
-    <XFoo data-foo={{true}}>
-      block
-    </XFoo>
-    <XFoo data-test-selector={{true}}>
-      block
-    </XFoo>
-    <XFoo data-test-selector={{post.id}}>
-      block
-    </XFoo>
-    <Common::AccordionComponent data-test-accordion as |accordion|>
-      block
-    </Common::AccordionComponent>
-    <XFoo data-foo @name=\\"Sophie\\" />"
+    "
+        <XFoo data-foo={{true}} />
+        <XFoo data-test-selector={{true}} />
+        <XFoo data-test-selector={{post.id}} />
+        <XFoo @label=\\"hi\\" data-test-selector={{true}} />
+        <XFoo data-test-foo />
+        
+        <XFoo data-foo={{true}}>
+          block
+        </XFoo>
+        
+        <XFoo data-test-selector={{true}}>
+          block
+        </XFoo>
+        
+        <XFoo data-test-selector={{post.id}}>
+          block
+        </XFoo>
+        
+        <Common::AccordionComponent data-test-accordion as |accordion|>
+          block
+        </Common::AccordionComponent>
+        
+        <XFoo data-foo @name=\\"Sophie\\" />
+      "
   `);
 });
 
@@ -162,31 +163,17 @@ test('deeply-nested-sub', () => {
   `;
 
   expect(runTest('deeply-nested-sub.hbs', input)).toMatchInlineSnapshot(`
-    "<SomeComponent class={{concat foo (some-helper ted (some-dude bar (a b c)))}}>
-      help
-    </SomeComponent>
-    <SomeComponent class={{concat foo (some-helper ted (some-dude bar (a b c)))}} />
-    <DeepComponent
-      class={{concat foo (nice-helper ted (some-crazy bar (a d (d e f))))}}
-    />
-    <SomeComponent class={{concat foo (some-helper bar)}} />
-    <SomeComponent class={{concat foo (some-helper bar quuz)}} />
-    <SomeComponent
-      @person={{hash name=\\"Sophie\\" age=1}}
-      @message={{t \\"welcome\\" count=1}}
-    />
-    <SomeComponent
-      @people={{array
-        (hash
-          name=\\"Alex\\"
-          age=5
-          nested=(hash oldest=true amount=(format-currency 350 sign=\\"£\\"))
-          disabled=(eq foo \\"bar\\")
-        )
-        (hash name=\\"Ben\\" age=4)
-        (hash name=\\"Sophie\\" age=1)
-      }}
-    />"
+    "
+        <SomeComponent class={{concat foo (some-helper ted (some-dude bar (a b c)))}}>
+          help
+        </SomeComponent>
+        <SomeComponent class={{concat foo (some-helper ted (some-dude bar (a b c)))}} />
+        <DeepComponent class={{concat foo (nice-helper ted (some-crazy bar (a d (d e f))))}} />
+        <SomeComponent class={{concat foo (some-helper bar)}} />
+        <SomeComponent class={{concat foo (some-helper bar quuz)}} />
+        <SomeComponent @person={{hash name=\\"Sophie\\" age=1}} @message={{t \\"welcome\\" count=1}} />
+        <SomeComponent @people={{array (hash name=\\"Alex\\" age=5 nested=(hash oldest=true amount=(format-currency 350 sign=\\"£\\")) disabled=(eq foo \\"bar\\")) (hash name=\\"Ben\\" age=4) (hash name=\\"Sophie\\" age=1)}} />
+      "
   `);
 });
 
@@ -200,11 +187,13 @@ test('each-in', () => {
   `;
 
   expect(runTest('each-in.hbs', input)).toMatchInlineSnapshot(`
-    "{{#each-in this.people as |name person|}}
-      Hello,{{name}}! You are{{person.age}}years old.
-    {{else}}
-      Sorry, nobody is here.
-    {{/each-in}}"
+    "
+        {{#each-in this.people as |name person|}}
+          Hello, {{name}}! You are {{person.age}} years old.
+        {{else}}
+          Sorry, nobody is here.
+        {{/each-in}}
+      "
   `);
 });
 
@@ -215,10 +204,10 @@ test('entities', () => {
   `;
 
   expect(runTest('entities.hbs', input)).toMatchInlineSnapshot(`
-    "&lt; &gt; &times;
-    <Foo data-a=\\"&quot;Foo&nbsp;&amp;&nbsp;Bar&quot;\\">
-      &nbsp;Some text &gt;
-    </Foo>"
+    "
+        &lt; &gt; &times;
+        <Foo data-a=\\"&quot;Foo&nbsp;&amp;&nbsp;Bar&quot;\\">&nbsp;Some text &gt;</Foo>
+      "
   `);
 });
 
@@ -247,29 +236,28 @@ test('html-tags', () => {
   `;
 
   expect(runTest('html-tags.hbs', input)).toMatchInlineSnapshot(`
-    "<input
-      type=\\"text\\"
-      value={{userValue}}
-      oninput={{action \\"change\\" value=\\"target.value\\"}}
-      class=\\"{{if invalid \\"invalid-input\\"}}\\"
-    />
-    <textarea
-      value={{userValue}}
-      oninput={{action \\"change\\" value=\\"target.value\\"}}
-      class=\\"{{if invalid \\"invalid-input\\"}}\\"
-    >
-      HI
-    </textarea>
-    <textarea
-      value={{userValue}}
-      oninput={{action (action \\"change\\") value=\\"target.value\\"}}
-      class=\\"{{if invalid \\"invalid-input\\"}}\\"
-    >
-      HI
-    </textarea>
-    <div onclick={{action \\"clickMe\\"}}></div>
-    <div data-foo=\\"{{if someThing yas nah}}\\"></div>
-    <div {{on \\"click\\" this.foo}}></div>"
+    "
+        <input 
+          type='text'
+          value={{userValue}}
+          oninput={{action 'change' value='target.value'}}
+          class=\\"{{if invalid 'invalid-input'}}\\"/>
+        
+        <textarea 
+          value={{userValue}}
+          oninput={{action 'change' value='target.value'}}
+          class=\\"{{if invalid 'invalid-input'}}\\">HI</textarea>
+        
+        <textarea 
+          value={{userValue}}
+          oninput={{action (action 'change') value='target.value'}}
+          class=\\"{{if invalid 'invalid-input'}}\\">HI</textarea>
+        
+        <div onclick={{action \\"clickMe\\"}}></div>
+        
+        <div data-foo=\\"{{if someThing yas nah}}\\"></div>
+        <div {{on 'click' this.foo}}></div>
+      "
   `);
 });
 
@@ -283,11 +271,13 @@ test('if', () => {
   `;
 
   expect(runTest('if.hbs', input)).toMatchInlineSnapshot(`
-    "{{#if (eq a b)}}
-      <MyComponent1 @prop1=\\"hello\\" />
-    {{else}}
-      <MyComponent2 @prop2=\\"world\\" />
-    {{/if}}"
+    "
+        {{#if (eq a b)}}
+          <MyComponent1 @prop1=\\"hello\\" />
+        {{else}}
+          <MyComponent2 @prop2=\\"world\\" />
+        {{/if}}
+      "
   `);
 });
 
@@ -297,11 +287,9 @@ test('input-helper', () => {
   `;
 
   expect(runTest('input-helper.hbs', input)).toMatchInlineSnapshot(`
-    "<Input
-      @type=\\"checkbox\\"
-      @name=\\"email-opt-in\\"
-      @checked={{this.model.emailPreference}}
-    />"
+    "
+        <Input @type=\\"checkbox\\" @name=\\"email-opt-in\\" @checked={{this.model.emailPreference}} />
+      "
   `);
 });
 
@@ -319,18 +307,17 @@ test('let', () => {
   `;
 
   expect(runTest('let.hbs', input)).toMatchInlineSnapshot(`
-    "{{#let
-      (capitalize this.person.firstName)
-      (capitalize this.person.lastName) as |firstName lastName|
-    }}
-      Welcome back
-      {{concat firstName \\" \\" lastName}}
-      Account Details:
-          First Name:
-      {{firstName}}
-      Last Name:
-      {{lastName}}
-    {{/let}}"
+    "
+        {{#let (capitalize this.person.firstName) (capitalize this.person.lastName)
+          as |firstName lastName|
+        }}
+          Welcome back {{concat firstName ' ' lastName}}
+        
+          Account Details:
+          First Name: {{firstName}}
+          Last Name: {{lastName}}
+        {{/let}}
+      "
   `);
 });
 
@@ -341,12 +328,10 @@ test('link-to', () => {
   `;
 
   expect(runTest('link-to.hbs', input)).toMatchInlineSnapshot(`
-    "<LinkTo @route=\\"about\\">
-      About Us
-    </LinkTo>
-    <LinkTo @route={{this.dynamicRoute}}>
-      About Us
-    </LinkTo>"
+    "
+        <LinkTo @route=\\"about\\">About Us</LinkTo>
+        <LinkTo @route={{this.dynamicRoute}}>About Us</LinkTo>
+      "
   `);
 });
 
@@ -378,34 +363,12 @@ test('link-to-inline', () => {
   `;
 
   expect(runTest('link-to-inline.hbs', input)).toMatchInlineSnapshot(`
-    "<LinkTo @route=\\"some.route\\">
-      Title
-    </LinkTo>
-    <LinkTo
-      @route=\\"apps.segments\\"
-      class=\\"tabs__discrete-tab\\"
-      @activeClass=\\"o__selected\\"
-      @current-when=\\"apps.segments\\"
-      data-test-segment-link=\\"segments\\"
-    >
-      Segments
-    </LinkTo>
-    <LinkTo
-      @route={{this.dynamicPath}}
-      class=\\"tabs__discrete-tab\\"
-      @activeClass=\\"o__selected\\"
-      @current-when=\\"apps.segments\\"
-      data-test-segment-link=\\"segments\\"
-    >
-      Segments
-    </LinkTo>
-    <LinkTo
-      @route=\\"apps.app.companies.segments.segment\\"
-      @model={{segment}}
-      class=\\"t__em-link\\"
-    >
-      {{segment.name}}
-    </LinkTo>"
+    "
+        <LinkTo @route=\\"some.route\\">Title</LinkTo>
+        <LinkTo @route=\\"apps.segments\\" class=\\"tabs__discrete-tab\\" @activeClass=\\"o__selected\\" @current-when=\\"apps.segments\\" data-test-segment-link=\\"segments\\">Segments</LinkTo>
+        <LinkTo @route={{this.dynamicPath}} class=\\"tabs__discrete-tab\\" @activeClass=\\"o__selected\\" @current-when=\\"apps.segments\\" data-test-segment-link=\\"segments\\">Segments</LinkTo>
+        <LinkTo @route=\\"apps.app.companies.segments.segment\\" @model={{segment}} class=\\"t__em-link\\">{{segment.name}}</LinkTo>
+      "
   `);
 });
 
@@ -417,21 +380,11 @@ test('link-to-model', () => {
   `;
 
   expect(runTest('link-to-model.hbs', input)).toMatchInlineSnapshot(`
-    "<LinkTo @route=\\"post\\" @model={{post}}>
-      Read
-      {{post.title}}
-      ...
-    </LinkTo>
-    <LinkTo @route=\\"post\\" @model=\\"string-id\\">
-      Read
-      {{post.title}}
-      ...
-    </LinkTo>
-    <LinkTo @route=\\"post\\" @model={{557}}>
-      Read
-      {{post.title}}
-      ...
-    </LinkTo>"
+    "
+        <LinkTo @route=\\"post\\" @model={{post}}>Read {{post.title}}...</LinkTo>
+        <LinkTo @route=\\"post\\" @model=\\"string-id\\">Read {{post.title}}...</LinkTo>
+        <LinkTo @route=\\"post\\" @model={{557}}>Read {{post.title}}...</LinkTo>
+      "
   `);
 });
 
@@ -446,18 +399,14 @@ test('link-to-model-array', () => {
   `;
 
   expect(runTest('link-to-model-array.hbs', input)).toMatchInlineSnapshot(`
-    "<LinkTo @route=\\"post.comment\\" @models={{array post comment}}>
-      Comment by
-      {{comment.author.name}}
-      on
-      {{comment.date}}
-    </LinkTo>
-    <LinkTo @route={{this.dynamicPath}} @models={{array post comment}}>
-      Comment by
-      {{comment.author.name}}
-      on
-      {{comment.date}}
-    </LinkTo>"
+    "
+        <LinkTo @route=\\"post.comment\\" @models={{array post comment}}>
+          Comment by {{comment.author.name}} on {{comment.date}}
+        </LinkTo>
+        <LinkTo @route={{this.dynamicPath}} @models={{array post comment}}>
+          Comment by {{comment.author.name}} on {{comment.date}}
+        </LinkTo>
+      "
   `);
 });
 
@@ -487,35 +436,24 @@ test('link-to-query-param', () => {
   `;
 
   expect(runTest('link-to-query-param.hbs', input)).toMatchInlineSnapshot(`
-    "<LinkTo @route=\\"posts\\" @query={{hash direction=\\"desc\\" showArchived=false}}>
-      Recent Posts
-    </LinkTo>
-    <LinkTo @route=\\"posts\\" data-test-foo>
-      Recent Posts
-    </LinkTo>
-    <LinkTo
-      @route={{this.dynamicPath}}
-      @query={{hash direction=\\"desc\\" showArchived=false}}
-    >
-      Recent Posts
-    </LinkTo>
-    <LinkTo
-      @route={{this.dynamicPath}}
-      @query={{hash direction=\\"desc\\" showArchived=false}}
-      data-test-foo
-    >
-      Recent Posts
-    </LinkTo>
-    <LinkTo @query={{hash direction=\\"desc\\" showArchived=false}}>
-      Recent Posts
-    </LinkTo>
-    <LinkTo
-      @route=\\"apps.app.users.segments.segment\\"
-      @model=\\"all-users\\"
-      @query={{hash searchTerm=searchTerm}}
-    >
-      Users
-    </LinkTo>"
+    "
+        <LinkTo @route=\\"posts\\" @query={{hash direction=\\"desc\\" showArchived=false}}>
+          Recent Posts
+        </LinkTo>
+        <LinkTo @route=\\"posts\\" data-test-foo>
+          Recent Posts
+        </LinkTo>
+        <LinkTo @route={{this.dynamicPath}} @query={{hash direction=\\"desc\\" showArchived=false}}>
+          Recent Posts
+        </LinkTo>
+        <LinkTo @route={{this.dynamicPath}} @query={{hash direction=\\"desc\\" showArchived=false}} data-test-foo>
+          Recent Posts
+        </LinkTo>
+        <LinkTo @query={{hash direction=\\"desc\\" showArchived=false}}>
+          Recent Posts
+        </LinkTo>
+        <LinkTo @route=\\"apps.app.users.segments.segment\\" @model=\\"all-users\\" @query={{hash searchTerm=searchTerm}}>Users</LinkTo>
+      "
   `);
 });
 
@@ -532,16 +470,16 @@ test('nested', () => {
   `;
 
   expect(runTest('nested.hbs', input)).toMatchInlineSnapshot(`
-    "<Ui::SiteHeader @user={{this.user}} class={{if this.user.isAdmin \\"admin\\"}} />
-    <Ui::Button @text=\\"Click me\\" />
-    <SomePath::AnotherPath::SuperSelect @selected={{this.user.country}} as |s|>
-      {{#each this.availableCountries as |country|}}
-        <s.option @value={{country}}>
-          {{country.name}}
-        </s.option>
-      {{/each}}
-    </SomePath::AnotherPath::SuperSelect>
-    <XFoo::XBar />"
+    "
+        <Ui::SiteHeader @user={{this.user}} class={{if this.user.isAdmin \\"admin\\"}} />
+        <Ui::Button @text=\\"Click me\\" />
+        <SomePath::AnotherPath::SuperSelect @selected={{this.user.country}} as |s|>
+          {{#each this.availableCountries as |country|}}
+            <s.option @value={{country}}>{{country.name}}</s.option>
+          {{/each}}
+        </SomePath::AnotherPath::SuperSelect>
+        <XFoo::XBar />
+      "
   `);
 });
 
@@ -550,9 +488,11 @@ test('null-subexp', () => {
     {{some-component selected=(is-equal this.bar null)}}
   `;
 
-  expect(runTest('null-subexp.hbs', input)).toMatchInlineSnapshot(
-    `"<SomeComponent @selected={{is-equal this.bar null}} />"`
-  );
+  expect(runTest('null-subexp.hbs', input)).toMatchInlineSnapshot(`
+    "
+        <SomeComponent @selected={{is-equal this.bar null}} />
+      "
+  `);
 });
 
 test('positional-params', () => {
@@ -569,15 +509,17 @@ test('positional-params', () => {
   `;
 
   expect(runTest('positional-params.hbs', input)).toMatchInlineSnapshot(`
-    "{{some-component \\"foo\\"}}
-    {{#some-component \\"foo\\"}}
-      hi
-    {{/some-component}}
-    {{#some-component foo}}
-      hi
-    {{/some-component}}
-    {{some-component 123}}
-    {{some-component (some-helper 987)}}"
+    "
+        {{some-component \\"foo\\"}}
+        {{#some-component \\"foo\\"}}
+          hi
+        {{/some-component}}
+        {{#some-component foo}}
+          hi
+        {{/some-component}}
+        {{some-component 123}}
+        {{some-component (some-helper 987)}}
+      "
   `);
 });
 
@@ -597,17 +539,19 @@ test('sample', () => {
   `;
 
   expect(runTest('sample.hbs', input)).toMatchInlineSnapshot(`
-    "<SiteHeader @user={{this.user}} class={{if this.user.isAdmin \\"admin\\"}} />
-    <SiteHeader @user={{null}} @address={{undefined}} />
-    <SuperSelect @selected={{this.user.country}} as |s|>
-      {{#each this.availableCountries as |country|}}
-        <s.option @value={{country}}>
-          {{country.name}}
-        </s.option>
-      {{/each}}
-    </SuperSelect>
-    <Foo::Bar @tagName=\\"\\" />
-    <Foo @tagName=\\"div\\" @a=\\"\\" @b=\\"\\" />"
+    "
+        <SiteHeader @user={{this.user}} class={{if this.user.isAdmin \\"admin\\"}} />
+        <SiteHeader @user={{null}} @address={{undefined}} />
+
+        <SuperSelect @selected={{this.user.country}} as |s|>
+          {{#each this.availableCountries as |country|}}
+            <s.option @value={{country}}>{{country.name}}</s.option>
+          {{/each}}
+        </SuperSelect>
+
+        <Foo::Bar @tagName=\\"\\" />
+        <Foo @tagName=\\"div\\" @a=\\"\\" @b=\\"\\" />
+      "
   `);
 });
 
@@ -624,16 +568,16 @@ test('sample2', () => {
   `;
 
   expect(runTest('sample2.hbs', input)).toMatchInlineSnapshot(`
-    "<MyCard as |card|>
-      <card.title @title=\\"My Card Title\\" />
-      <card.content>
-        <p>
-          hello
-        </p>
-      </card.content>
-      <card.foo-bar />
-      {{card.foo}}
-    </MyCard>"
+    "
+        <MyCard as |card|>
+          <card.title @title=\\"My Card Title\\" />
+          <card.content>
+            <p>hello</p>
+          </card.content>
+          <card.foo-bar />
+          {{card.foo}}
+        </MyCard>
+      "
   `);
 });
 
@@ -642,9 +586,11 @@ test('t-helper', () => {
     {{t "some.string" param="string" another=1}}
   `;
 
-  expect(runTest('t-helper.hbs', input)).toMatchInlineSnapshot(
-    `"{{t \\"some.string\\" param=\\"string\\" another=1}}"`
-  );
+  expect(runTest('t-helper.hbs', input)).toMatchInlineSnapshot(`
+    "
+        {{t \\"some.string\\" param=\\"string\\" another=1}}
+      "
+  `);
 });
 
 test('tag-name', () => {
@@ -652,7 +598,11 @@ test('tag-name', () => {
     {{foo/bar name=""}}
   `;
 
-  expect(runTest('tag-name.hbs', input)).toMatchInlineSnapshot(`"<Foo::Bar @name=\\"\\" />"`);
+  expect(runTest('tag-name.hbs', input)).toMatchInlineSnapshot(`
+    "
+        <Foo::Bar @name=\\"\\" />
+      "
+  `);
 });
 
 test('textarea', () => {
@@ -660,9 +610,11 @@ test('textarea', () => {
     {{textarea value=this.model.body}}
   `;
 
-  expect(runTest('textarea.hbs', input)).toMatchInlineSnapshot(
-    `"<Textarea @value={{this.model.body}} />"`
-  );
+  expect(runTest('textarea.hbs', input)).toMatchInlineSnapshot(`
+    "
+        <Textarea @value={{this.model.body}} />
+      "
+  `);
 });
 
 test('tilde', () => {
@@ -686,9 +638,11 @@ test('undefined-subexp', () => {
     {{some-component selected=(is-equal this.bar undefined)}}
   `;
 
-  expect(runTest('undefined-subexp.hbs', input)).toMatchInlineSnapshot(
-    `"<SomeComponent @selected={{is-equal this.bar undefined}} />"`
-  );
+  expect(runTest('undefined-subexp.hbs', input)).toMatchInlineSnapshot(`
+    "
+        <SomeComponent @selected={{is-equal this.bar undefined}} />
+      "
+  `);
 });
 
 test('unless', () => {
@@ -699,9 +653,11 @@ test('unless', () => {
   `;
 
   expect(runTest('unless.hbs', input)).toMatchInlineSnapshot(`
-    "{{#unless this.hasPaid}}
-      You owe: \${{this.total}}
-    {{/unless}}"
+    "
+        {{#unless this.hasPaid}}
+          You owe: \${{this.total}}
+        {{/unless}}
+      "
   `);
 });
 
@@ -740,37 +696,34 @@ test('skip-default-helpers', () => {
   };
 
   expect(runTest('skip-default-helpers.hbs', input, options)).toMatchInlineSnapshot(`
-    "<div id=\\"main-container\\">
-      {{liquid-outlet}}
-    </div>
-    <button {{action \\"toggle\\" \\"showA\\"}}>
-      Toggle A/B
-    </button>
-    <button {{action \\"toggle\\" \\"showOne\\"}}>
-      Toggle One/Two
-    </button>
-    {{#liquid-if showOne class=\\"nested-explode-transition-scenario\\"}}
-      <div class=\\"child\\">
-        {{#liquid-if showA use=\\"toLeft\\"}}
-          <div class=\\"child-one-a\\">
-            One: A
+    "
+        <div id=\\"main-container\\">
+          {{liquid-outlet}}
+        </div>
+        <button {{action \\"toggle\\" \\"showA\\"}}>
+          Toggle A/B</button>
+        <button {{action \\"toggle\\" \\"showOne\\"}}>
+          Toggle One/Two
+        </button>
+        {{#liquid-if showOne class=\\"nested-explode-transition-scenario\\"}}
+          <div class=\\"child\\">
+            {{#liquid-if showA use=\\"toLeft\\"}}
+              <div class=\\"child-one-a\\">One: A</div>
+            {{else}}
+              <div class=\\"child-one-b\\">One: B</div>
+            {{/liquid-if}}
           </div>
         {{else}}
-          <div class=\\"child-one-b\\">
-            One: B
+          <div class=\\"child child-two\\">
+            Two
           </div>
         {{/liquid-if}}
-      </div>
-    {{else}}
-      <div class=\\"child child-two\\">
-        Two
-      </div>
-    {{/liquid-if}}
-    {{moment \\"12-25-1995\\" \\"MM-DD-YYYY\\"}}
-    {{moment-from \\"1995-12-25\\" \\"2995-12-25\\" hideAffix=true}}
-    <SomeComponent @foo={{true}} />
-    {{some-helper1 foo=true}}
-    {{some-helper2 foo=true}}"
+        {{moment '12-25-1995' 'MM-DD-YYYY'}}
+        {{moment-from '1995-12-25' '2995-12-25' hideAffix=true}}
+        <SomeComponent @foo={{true}} />
+        {{some-helper1 foo=true}}
+        {{some-helper2 foo=true}}
+      "
   `);
 });
 
@@ -805,37 +758,34 @@ test('skip-default-helpers (no-config)', () => {
   `;
 
   expect(runTest('skip-default-helpers.hbs', input)).toMatchInlineSnapshot(`
-    "<div id=\\"main-container\\">
-      {{liquid-outlet}}
-    </div>
-    <button {{action \\"toggle\\" \\"showA\\"}}>
-      Toggle A/B
-    </button>
-    <button {{action \\"toggle\\" \\"showOne\\"}}>
-      Toggle One/Two
-    </button>
-    {{#liquid-if showOne class=\\"nested-explode-transition-scenario\\"}}
-      <div class=\\"child\\">
-        {{#liquid-if showA use=\\"toLeft\\"}}
-          <div class=\\"child-one-a\\">
-            One: A
+    "
+        <div id=\\"main-container\\">
+          {{liquid-outlet}}
+        </div>
+        <button {{action \\"toggle\\" \\"showA\\"}}>
+          Toggle A/B</button>
+        <button {{action \\"toggle\\" \\"showOne\\"}}>
+          Toggle One/Two
+        </button>
+        {{#liquid-if showOne class=\\"nested-explode-transition-scenario\\"}}
+          <div class=\\"child\\">
+            {{#liquid-if showA use=\\"toLeft\\"}}
+              <div class=\\"child-one-a\\">One: A</div>
+            {{else}}
+              <div class=\\"child-one-b\\">One: B</div>
+            {{/liquid-if}}
           </div>
         {{else}}
-          <div class=\\"child-one-b\\">
-            One: B
+          <div class=\\"child child-two\\">
+            Two
           </div>
         {{/liquid-if}}
-      </div>
-    {{else}}
-      <div class=\\"child child-two\\">
-        Two
-      </div>
-    {{/liquid-if}}
-    {{moment \\"12-25-1995\\" \\"MM-DD-YYYY\\"}}
-    {{moment-from \\"1995-12-25\\" \\"2995-12-25\\" hideAffix=true}}
-    <SomeComponent @foo={{true}} />
-    <SomeHelper1 @foo={{true}} />
-    <SomeHelper2 @foo={{true}} />"
+        {{moment '12-25-1995' 'MM-DD-YYYY'}}
+        {{moment-from '1995-12-25' '2995-12-25' hideAffix=true}}
+        <SomeComponent @foo={{true}} />
+        <SomeHelper1 @foo={{true}} />
+        <SomeHelper2 @foo={{true}} />
+      "
   `);
 });
 
@@ -855,11 +805,13 @@ test('custom-options', () => {
   };
 
   expect(runTest('custom-options.hbs', input, options)).toMatchInlineSnapshot(`
-    "<SomeComponent @foo={{true}} />
-    {{some-helper1 foo=true}}
-    {{some-helper2 foo=true}}
-    {{link-to \\"Title\\" \\"some.route\\"}}
-    {{textarea value=this.model.body}}
-    {{input type=\\"checkbox\\" name=\\"email-opt-in\\" checked=this.model.emailPreference}}"
+    "
+        <SomeComponent @foo={{true}} />
+        {{some-helper1 foo=true}}
+        {{some-helper2 foo=true}}
+        {{link-to \\"Title\\" \\"some.route\\"}}
+        {{textarea value=this.model.body}}
+        {{input type=\\"checkbox\\" name=\\"email-opt-in\\" checked=this.model.emailPreference}}
+      "
   `);
 });

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -254,10 +254,9 @@ function transformToAngleBracket(env, fileInfo, config) {
       }
 
       if (_valueType === 'PathExpression') {
-        _value = b.mustache(b.path(a.value));
+        _value = b.mustache(a.value);
       } else if (_valueType === 'SubExpression') {
         if (a.value.hash.pairs.length > 0) {
-          // _value = b.mustache(a.value.path.original, a.value.params, a.value.hash);
           a.value.type = 'MustacheStatement';
           _value = a.value;
         } else {
@@ -487,14 +486,6 @@ function transformToAngleBracket(env, fileInfo, config) {
       if (!shouldIgnoreMustacheStatement(node.path.original)) {
         return transformNode(node);
       }
-    },
-
-    ElementNode(node) {
-      node.attributes.forEach(a => {
-        if (a.value && a.value.chars === '' && a.value.chars === _EMPTY_STRING_) {
-          a.value = b.text(_EMPTY_STRING_);
-        }
-      });
     },
   };
 }

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -1,5 +1,4 @@
-const glimmer = require('@glimmer/syntax');
-const prettier = require('prettier');
+const recast = require('ember-template-recast');
 
 const _EMPTY_STRING_ = `ANGLE_BRACKET_EMPTY_${Date.now()}`;
 
@@ -227,12 +226,20 @@ module.exports = function transform(fileInfo, config) {
     return fileInfo.source;
   }
 
-  const ast = glimmer.preprocess(fileInfo.source, {
-    mode: 'codemod',
-    parseOptions: { ignoreStandalone: true },
-  });
+  let { code: toAngleBracket } = recast.transform(fileInfo.source, env =>
+    transformToAngleBracket(env, fileInfo, config)
+  );
 
-  const b = glimmer.builders;
+  let attrEqualEmptyString = new RegExp(_EMPTY_STRING_, 'gi');
+  let dataEqualsNoValue = /(data-\S+)=""/gim;
+
+  toAngleBracket = toAngleBracket.replace(attrEqualEmptyString, '');
+  toAngleBracket = toAngleBracket.replace(dataEqualsNoValue, '$1');
+  return toAngleBracket;
+};
+
+function transformToAngleBracket(env, fileInfo, config) {
+  let { builders: b } = env.syntax;
 
   /**
    * Transform the attributes names & values properly
@@ -247,10 +254,12 @@ module.exports = function transform(fileInfo, config) {
       }
 
       if (_valueType === 'PathExpression') {
-        _value = b.mustache(b.path(a.value.original));
+        _value = b.mustache(b.path(a.value));
       } else if (_valueType === 'SubExpression') {
         if (a.value.hash.pairs.length > 0) {
-          _value = b.mustache(a.value.path.original, a.value.params, a.value.hash);
+          // _value = b.mustache(a.value.path.original, a.value.params, a.value.hash);
+          a.value.type = 'MustacheStatement';
+          _value = a.value;
         } else {
           const params = a.value.params
             .map(p => {
@@ -281,7 +290,6 @@ module.exports = function transform(fileInfo, config) {
       } else {
         _value = b.text(a.value.original || _EMPTY_STRING_);
       }
-
       return b.attr(_key, _value);
     });
   }
@@ -411,6 +419,7 @@ module.exports = function transform(fileInfo, config) {
   }
 
   function transformNode(node) {
+    let selfClosing = node.type !== 'BlockStatement';
     const tagName = node.path.original;
 
     if (config.skipBuiltInComponents && BUILT_IN_COMPONENTS.includes(tagName)) {
@@ -424,8 +433,10 @@ module.exports = function transform(fileInfo, config) {
     let blockParams = node.program ? node.program.blockParams : undefined;
 
     if (tagName === 'link-to') {
+      selfClosing = false;
+
       if (node.type === 'MustacheStatement') {
-        let params = node.params;
+        let params = node.params.slice();
         let textParam = params.shift(); //the first param becomes the block content
 
         attributes = transformLinkToAttrs(params);
@@ -443,18 +454,20 @@ module.exports = function transform(fileInfo, config) {
         );
         return;
       }
-
       attributes = transformNodeAttributes(node);
     }
 
-    return b.element(newTagName, {
-      attrs: attributes,
-      children,
-      blockParams,
-    });
+    return b.element(
+      { name: newTagName, selfClosing },
+      {
+        attrs: attributes,
+        children,
+        blockParams,
+      }
+    );
   }
 
-  glimmer.traverse(ast, {
+  return {
     MustacheStatement(node) {
       // Don't change attribute statements
       const isValidMustache =
@@ -478,19 +491,10 @@ module.exports = function transform(fileInfo, config) {
 
     ElementNode(node) {
       node.attributes.forEach(a => {
-        if (a.value && a.value.chars === '') {
+        if (a.value && a.value.chars === '' && a.value.chars === _EMPTY_STRING_) {
           a.value = b.text(_EMPTY_STRING_);
         }
       });
     },
-  });
-
-  let attrEqualEmptyString = new RegExp(_EMPTY_STRING_, 'gi');
-  let dataEqualsNoValue = /(data-\S+)=""/gim;
-
-  // Haxx out valueless data-* and args with the empty string
-
-  let uglySource = glimmer.print(ast).replace(attrEqualEmptyString, '');
-  let dataOk = uglySource.replace(dataEqualsNoValue, '$1');
-  return prettier.format(dataOk, { parser: 'glimmer' });
-};
+  };
+}


### PR DESCRIPTION
refactors to ease modification and to support ember template recast a bit better