### PR TITLE
ESLint: Fix test path pattern

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     "prettier/prettier": "error"
   },
   overrides: [{
-    files: ['**/*.test.js'],
+    files: ['**/test.js'],
     env: {
       jest: true
     }


### PR DESCRIPTION
Apparently we currently only support running tests in `test.js` files due to how `codemod-cli` is implemented 🤔 