### PR TITLE
bin/cli: Set correct file extension

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,5 +4,6 @@
 require('codemod-cli').runTransform(
   __dirname,
   process.argv[2] /* transform name */,
-  process.argv.slice(3) /* paths or globs */
+  process.argv.slice(3) /* paths or globs */,
+  'hbs'
 );


### PR DESCRIPTION
Without this change the codemod would only run on JS files 😱 

This configures the codemod to run on Handlebars files instead of JS files.