### PR TITLE
Adjust `tilde` test fixture

### DIFF
--- a/transforms/angle-brackets/__snapshots__/test.js.snap
+++ b/transforms/angle-brackets/__snapshots__/test.js.snap
@@ -701,11 +701,11 @@ exports[`textarea 1`] = `
 
 exports[`tilde 1`] = `
 "{{#if foo~}}
-  bar
+  {{some-component}}
 {{/if}}
 ~~~~~~~~
 {{#if foo~}}
-  bar
+  {{some-component}}
 {{/if}}"
 `;
 

--- a/transforms/angle-brackets/test.js
+++ b/transforms/angle-brackets/test.js
@@ -402,7 +402,7 @@ test('textarea', () => {
 test('tilde', () => {
   let input = `
     {{#if foo~}}
-      bar
+      {{some-component}}
     {{/if}}
   `;
 


### PR DESCRIPTION
The previous fixture wasn't actually checking the implemented behavior of completely ignoring templates that include a tilde character.