### PR TITLE
Skip block component conversion if the component has an `inverse` block

### DIFF
--- a/transforms/angle-brackets/test.js
+++ b/transforms/angle-brackets/test.js
@@ -981,3 +981,23 @@ test('handles link-to concat with hash', () => {
       "
   `);
 });
+
+test('component-else', () => {
+  let input = `
+    {{#foo bar="baz"}}
+      42
+    {{else}}
+      123
+    {{/foo}}
+  `;
+
+  expect(runTest('component-else.hbs', input)).toMatchInlineSnapshot(`
+    "
+        {{#foo bar=\\"baz\\"}}
+          42
+        {{else}}
+          123
+        {{/foo}}
+      "
+  `);
+});

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -340,6 +340,10 @@ function transformToAngleBracket(env, fileInfo, config) {
       return;
     }
 
+    if (node.inverse) {
+      return;
+    }
+
     const newTagName = transformTagName(tagName);
 
     let attributes;


### PR DESCRIPTION
This was causing issues in our app in a few rare cases where this feature was unfortunately used :-/