### PR TITLE
Add support for templates containing `~` (whitespace control)

### DIFF
--- a/transforms/angle-brackets/test.js
+++ b/transforms/angle-brackets/test.js
@@ -725,7 +725,7 @@ test('tilde', () => {
   expect(runTest('tilde.hbs', input)).toMatchInlineSnapshot(`
     "
         {{#if foo~}}
-          {{some-component}}
+          <SomeComponent />
         {{/if}}
       "
   `);

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -90,14 +90,6 @@ function transformNestedSubExpression(subExpression) {
 function shouldSkipFile(fileInfo, config) {
   let source = fileInfo.source;
 
-  if (source.includes('~')) {
-    //skip files with `~` until https://github.com/ember-codemods/ember-angle-brackets-codemod/issues/46 is resolved
-    logger.warn(
-      `WARNING: ${fileInfo.path} was not converted as it contains a "~" (https://github.com/ember-codemods/ember-angle-brackets-codemod/issues/46)`
-    );
-    return true;
-  }
-
   if (config.skipFilesThatMatchRegex && config.skipFilesThatMatchRegex.test(source)) {
     logger.warn(
       `WARNING: ${fileInfo.path} was not skipped as its content matches the "skipFilesThatMatchRegex" config setting: ${config.skipFilesThatMatchRegex}`


### PR DESCRIPTION
Enabled by https://github.com/glimmerjs/glimmer-vm/pull/983

Resolves #46

/cc @GavinJoyce 