### PR TITLE
fix wallstreet integration with telemetry data

### DIFF
--- a/transforms/angle-brackets/telemetry/mock-invokables.js
+++ b/transforms/angle-brackets/telemetry/mock-invokables.js
@@ -92,4 +92,13 @@ module.exports = {
   'app/components/foo-bar': {
     type: 'Component',
   },
+  'app/components/baz-bang/foo-bar/bang': {
+    type: 'Component',
+  },
+  'app/helpers/helper-1': {
+    type: 'Helper',
+  },
+  'app/helpers/nested/helper': {
+    type: 'Helper',
+  },
 };

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -270,9 +270,19 @@ function getNonDataAttributesFromParams(params) {
   return params.filter(p => !(p.original && `${p.original}`.startsWith('data-')));
 }
 
-function shouldIgnoreMustacheStatement(name, config, invokableData) {
+function shouldIgnoreMustacheStatement(fullName, config, invokableData) {
   let { helpers, components } = invokableData;
   let isTelemetryData = !!(helpers || components);
+
+  let name = fullName;
+  // replace `::` with `/`, and ignore the path before $
+  if (isWallStreet(name)) {
+    name = name
+      .split('$')
+      .pop()
+      .replace('::', '/');
+  }
+
   if (isTelemetryData) {
     let mergedHelpers = [...KNOWN_HELPERS, ...(helpers || [])];
     let isHelper = mergedHelpers.includes(name) || config.helpers.includes(name);
@@ -403,9 +413,6 @@ function transformToAngleBracket(fileInfo, config, invokableData) {
         isValidMustache &&
         (node.hash.pairs.length > 0 || node.params.length > 0 || isNestedComponent)
       ) {
-        return transformNode(node, fileInfo, config);
-      }
-      if (isWallStreet(tagName)) {
         return transformNode(node, fileInfo, config);
       }
     },

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -1049,12 +1049,12 @@ test('hyphens with nested usage', () => {
 
 test('wallstreet', () => {
   let input = `
-    {{#foo-bar$baz-bang/foo-bar::bang}}
+    {{#foo-bar$baz-bang/foo-bar/bang}}
       <div ...attributes>
         {{foo bar="baz"}}
       </div>
-    {{/foo-bar$baz-bang/foo-bar::bang}}
-    {{foo-bar$baz-bang/foo-bar::bang}}
+    {{/foo-bar$baz-bang/foo-bar/bang}}
+    {{foo-bar$baz-bang/foo-bar/bang}}
   `;
 
   expect(runTest('wallstreet.hbs', input)).toMatchInlineSnapshot(`
@@ -1065,6 +1065,26 @@ test('wallstreet', () => {
           </div>
         </FooBar$BazBang::FooBar::Bang>
         <FooBar$BazBang::FooBar::Bang />
+      "
+  `);
+});
+
+test('wallstreet-telemetry', () => {
+  let input = `
+    {{nested$helper}}
+    {{nested::helper}}
+    {{nested$helper param="cool!"}}
+    {{nested::helper param="yeah!"}}
+    {{helper-1}}
+  `;
+
+  expect(runTest('wallstreet-telemetry.hbs', input)).toMatchInlineSnapshot(`
+    "
+        {{nested$helper}}
+        {{nested::helper}}
+        {{nested$helper param=\\"cool!\\"}}
+        {{nested::helper param=\\"yeah!\\"}}
+        {{helper-1}}
       "
   `);
 });


### PR DESCRIPTION
previously, telemetry (helpers + components arrays) would only include the path after the `/helpers/` section of the string. for most apps, this meant that 
```
app/helpers/my/cool/helper
```
would be stored in the helpers array as 
```
"my/cool/helper"
```

for apps using engines & wallstreet syntax, the `MustacheStatement` transform for namespaced components would be looking for the helper/component using the namespaced key, which would never exist.

This PR changes the transform to strip out the namespace (anything before `$`), and replace any `::` with `/`'s to ensure that the transform uses the same syntax as the telemetry data