### PR TITLE
Fix false negatives for `link-to` with `data-` prefixed route name

### DIFF
--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -262,12 +262,16 @@ function transformNodeAttributes(tagName, node) {
   return node.params.concat(attributes);
 }
 
+function isDataAttrPathExpression(node) {
+  return node.type === 'PathExpression' && node.original.startsWith('data-');
+}
+
 function getDataAttributesFromParams(params) {
-  return params.filter(p => p.type === 'PathExpression' && p.original.startsWith('data-'));
+  return params.filter(it => isDataAttrPathExpression(it));
 }
 
 function getNonDataAttributesFromParams(params) {
-  return params.filter(p => p.type === 'StringLiteral' || !`${p.original}`.startsWith('data-'));
+  return params.filter(it => !isDataAttrPathExpression(it));
 }
 
 function shouldIgnoreMustacheStatement(fullName, config, invokableData) {

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -264,7 +264,7 @@ function transformNodeAttributes(tagName, node) {
 
 function getDataAttributesFromParams(params) {
   return params.filter(
-    p => p.original && `${p.original}`.startsWith('data-') && p.type !== 'StringLiteral'
+    p => p.original && `${p.original}`.startsWith('data-') && p.type === 'PathExpression'
   );
 }
 

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -263,11 +263,15 @@ function transformNodeAttributes(tagName, node) {
 }
 
 function getDataAttributesFromParams(params) {
-  return params.filter(param => param.original && `${param.original}`.startsWith('data-'));
+  return params.filter(
+    p => p.original && `${p.original}`.startsWith('data-') && p.type !== 'StringLiteral'
+  );
 }
 
 function getNonDataAttributesFromParams(params) {
-  return params.filter(p => !(p.original && `${p.original}`.startsWith('data-')));
+  return params.filter(
+    p => !(p.original && `${p.original}`.startsWith('data-')) || p.type === 'StringLiteral'
+  );
 }
 
 function shouldIgnoreMustacheStatement(fullName, config, invokableData) {

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -263,15 +263,11 @@ function transformNodeAttributes(tagName, node) {
 }
 
 function getDataAttributesFromParams(params) {
-  return params.filter(
-    p => p.original && `${p.original}`.startsWith('data-') && p.type === 'PathExpression'
-  );
+  return params.filter(p => p.type === 'PathExpression' && p.original.startsWith('data-'));
 }
 
 function getNonDataAttributesFromParams(params) {
-  return params.filter(
-    p => !(p.original && `${p.original}`.startsWith('data-')) || p.type === 'StringLiteral'
-  );
+  return params.filter(p => p.type === 'StringLiteral' || !`${p.original}`.startsWith('data-'));
 }
 
 function shouldIgnoreMustacheStatement(fullName, config, invokableData) {

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -376,6 +376,7 @@ test('let', () => {
 test('link-to', () => {
   let input = `
     {{#link-to "about"}}About Us{{/link-to}}
+    {{#link-to "data-access"}}Accessing the Crates.io Data{{/link-to}}
     {{#link-to this.dynamicRoute}}About Us{{/link-to}}
     {{#link-to "user" this.first this.second}}Show{{/link-to}}
     {{#link-to "user" this.first this.second (query-params foo="baz")}}Show{{/link-to}}
@@ -386,6 +387,7 @@ test('link-to', () => {
   expect(runTest('link-to.hbs', input)).toMatchInlineSnapshot(`
     "
         <LinkTo @route=\\"about\\">About Us</LinkTo>
+        <LinkTo @route=\\"data-access\\">Accessing the Crates.io Data</LinkTo>
         <LinkTo @route={{this.dynamicRoute}}>About Us</LinkTo>
         <LinkTo @route=\\"user\\" @models={{array this.first this.second}}>Show</LinkTo>
         <LinkTo @route=\\"user\\" @models={{array this.first this.second}} @query={{hash foo=\\"baz\\"}}>Show</LinkTo>


### PR DESCRIPTION
The original logic would consider any parameter a data attribute if the `original` had the substring `data-` .  This fix further reduces the ambiguity of the  parameter by enforcing that it also can't be a `StringLiteral` and that it must be a `PathExpression`

This fixes #212 