### PR TITLE
Accept `skipAttributesThatMatchRegex ` option values as an array of regex strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For example, with the configuration below, all attributes that matches either `/
 {
   "helpers": [],
   "skipBuiltInComponents": true,
-  "skipAttributesThatMatchRegex": [/data-/gim, /aria-/gim]
+  "skipAttributesThatMatchRegex": ["/data-/gim", "/aria-/gim"]
 }
 ```
 

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -25,7 +25,14 @@ function isAttribute(key) {
  */
 function shouldSkipAttribute(key, config) {
   if (config.skipAttributesThatMatchRegex && config.skipAttributesThatMatchRegex.length) {
-    return config.skipAttributesThatMatchRegex.some(rx => rx.test(key));
+    return config.skipAttributesThatMatchRegex.some(rx => {
+      // Get the user provided string and convert it to regex.
+      const match = /^\/(.*)\/([a-z]*)$/.exec(rx);
+      if (match) {
+        const regex = new RegExp(match[1], match[2]);
+        return regex.test(key);
+      }
+    });
   }
   return false;
 }

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -967,6 +967,22 @@ test('skip-attributes', () => {
   `);
 });
 
+test('skip-attributes with invalid regex', () => {
+  let input = `
+    {{some-component data-test-foo=true aria-label="bar" foo=true}}
+  `;
+
+  let options = {
+    skipAttributesThatMatchRegex: [null],
+  };
+
+  expect(runTest('ignore-attributes.hbs', input, options)).toMatchInlineSnapshot(`
+    "
+        <SomeComponent @data-test-foo={{true}} @aria-label=\\"bar\\" @foo={{true}} />
+      "
+  `);
+});
+
 test('regex-options', () => {
   let input = `
     {{some-component foo=true}}

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -957,7 +957,7 @@ test('skip-attributes', () => {
   `;
 
   let options = {
-    skipAttributesThatMatchRegex: [/data-/gim, /aria-/gim],
+    skipAttributesThatMatchRegex: ['/data-/gim', '/aria-/gim'],
   };
 
   expect(runTest('ignore-attributes.hbs', input, options)).toMatchInlineSnapshot(`


### PR DESCRIPTION
Fixes #228 