### PR TITLE
Add skipAttributesThatMatchRegex to config

### DIFF
--- a/transforms/angle-brackets/index.js
+++ b/transforms/angle-brackets/index.js
@@ -17,6 +17,10 @@ function getOptions() {
       options.helpers = config.helpers;
     }
 
+    if (config.skipAttributesThatMatchRegex) {
+      options.skipAttributesThatMatchRegex = config.skipAttributesThatMatchRegex;
+    }
+
     if (config.skipFilesThatMatchRegex) {
       options.skipFilesThatMatchRegex = new RegExp(config.skipFilesThatMatchRegex);
     }

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -960,7 +960,7 @@ test('skip-attributes', () => {
     skipAttributesThatMatchRegex: ['/data-/gim', '/aria-/gim'],
   };
 
-  expect(runTest('ignore-attributes.hbs', input, options)).toMatchInlineSnapshot(`
+  expect(runTest('skip-attributes.hbs', input, options)).toMatchInlineSnapshot(`
     "
         <SomeComponent data-test-foo={{true}} aria-label=\\"bar\\" @foo={{true}} />
       "
@@ -976,7 +976,7 @@ test('skip-attributes with invalid regex', () => {
     skipAttributesThatMatchRegex: [null],
   };
 
-  expect(runTest('ignore-attributes.hbs', input, options)).toMatchInlineSnapshot(`
+  expect(runTest('skip-attributes-invalid-regex.hbs', input, options)).toMatchInlineSnapshot(`
     "
         <SomeComponent @data-test-foo={{true}} @aria-label=\\"bar\\" @foo={{true}} />
       "


### PR DESCRIPTION
`skipAttributesThatMatchRegex` wasn't getting included in the transform config