### PR TITLE
Add config to enable transform on valueless attrs

### DIFF
--- a/transforms/angle-brackets/index.js
+++ b/transforms/angle-brackets/index.js
@@ -25,6 +25,7 @@ function getOptions() {
       options.skipFilesThatMatchRegex = new RegExp(config.skipFilesThatMatchRegex);
     }
 
+    options.includeValuelessDataTestAttributes = !!config.includeValuelessDataTestAttributes;
     options.skipBuiltInComponents = !!config.skipBuiltInComponents;
   }
 

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -280,6 +280,16 @@ function hasValuelessDataParams(params) {
   return getDataAttributesFromParams(params).length > 0;
 }
 
+function shouldSkipDataTestDataParams(node, includeValuelessDataTestAttributes) {
+  // data-* attributes are generally omitted,
+  // but this config allows including data-test-* attributes.
+  if (includeValuelessDataTestAttributes) {
+    const dataAttrs = getDataAttributesFromParams(node.params);
+    return !dataAttrs.some(p => p.original.indexOf('data-test') === 0);
+  }
+  return true;
+}
+
 function transformNodeAttributes(tagName, node, config) {
   let attributes = transformAttrs(tagName, node.hash.pairs, config);
   return node.params.concat(attributes);
@@ -338,7 +348,10 @@ function nodeHasPositionalParameters(node) {
 }
 
 function transformNode(node, fileInfo, config) {
-  if (hasValuelessDataParams(node.params)) {
+  if (
+    hasValuelessDataParams(node.params) &&
+    shouldSkipDataTestDataParams(node, config.includeValuelessDataTestAttributes)
+  ) {
     return;
   }
   let selfClosing = node.type !== 'BlockStatement';

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -280,12 +280,16 @@ function hasValuelessDataParams(params) {
   return getDataAttributesFromParams(params).length > 0;
 }
 
-function shouldSkipDataTestDataParams(node, includeValuelessDataTestAttributes) {
-  // data-* attributes are generally omitted,
-  // but this config allows including data-test-* attributes.
+/**
+ *
+ * data-* attributes are generally omitted,
+ * but this config allows including nodes with data-test-* attributes.
+ * Note this also includes nodes with both data-test-* and data-* attributes.
+ */
+function shouldSkipDataTestParams(params, includeValuelessDataTestAttributes) {
   if (includeValuelessDataTestAttributes) {
-    const dataAttrs = getDataAttributesFromParams(node.params);
-    return !dataAttrs.some(p => p.original.indexOf('data-test') === 0);
+    const dataAttrs = getDataAttributesFromParams(params);
+    return !dataAttrs.some(attr => attr.original.startsWith('data-test'));
   }
   return true;
 }
@@ -350,7 +354,7 @@ function nodeHasPositionalParameters(node) {
 function transformNode(node, fileInfo, config) {
   if (
     hasValuelessDataParams(node.params) &&
-    shouldSkipDataTestDataParams(node, config.includeValuelessDataTestAttributes)
+    shouldSkipDataTestParams(node.params, config.includeValuelessDataTestAttributes)
   ) {
     return;
   }

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -284,11 +284,12 @@ function hasValuelessDataParams(params) {
  *
  * data-* attributes are generally omitted,
  * but this config allows including nodes with data-test-* attributes.
- * Note this also includes nodes with both data-test-* and data-* attributes.
  */
 function shouldSkipDataTestParams(params, includeValuelessDataTestAttributes) {
   if (includeValuelessDataTestAttributes) {
     const dataAttrs = getDataAttributesFromParams(params);
+    // This is true for nodes with data-* attributes too,
+    // as long as there is one with data-test-* attribute.
     return !dataAttrs.some(attr => attr.original.startsWith('data-test'));
   }
   return true;

--- a/transforms/angle-brackets/transform.js
+++ b/transforms/angle-brackets/transform.js
@@ -290,7 +290,7 @@ function shouldSkipDataTestParams(params, includeValuelessDataTestAttributes) {
     const dataAttrs = getDataAttributesFromParams(params);
     // This is true for nodes with data-* attributes too,
     // as long as there is one with data-test-* attribute.
-    return !dataAttrs.some(attr => attr.original.startsWith('data-test'));
+    return !dataAttrs.some(attr => attr.original.startsWith('data-test-'));
   }
   return true;
 }

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -144,6 +144,99 @@ test('data-attributes', () => {
   `);
 });
 
+test('data-test-attributes', () => {
+  let options = {
+    includeValuelessDataTestAttributes: true,
+  };
+  let input = `
+    {{x-foo data-foo=true}}
+    {{x-foo data-test-selector=true}}
+    {{x-foo data-test-selector=post.id}}
+    {{x-foo label="hi" data-test-selector=true}}
+    {{x-foo data-test-foo }}
+
+    {{#x-foo data-foo=true}}
+      block
+    {{/x-foo}}
+
+    {{#x-foo data-test-selector=true}}
+      block
+    {{/x-foo}}
+
+    {{#x-foo data-test-selector=post.id}}
+      block
+    {{/x-foo}}
+
+    {{#common/accordion-component data-test-accordion as |accordion|}}
+      block
+    {{/common/accordion-component}}
+
+    {{x-foo
+      data-foo
+      name="Sophie"
+    }}
+
+    {{#link-to data-test-foo "posts"}}
+      Recent Posts
+    {{/link-to}}
+    {{#link-to data-test-foo this.dynamicPath (query-params direction="desc" showArchived=false)}}
+      Recent Posts
+    {{/link-to}}
+
+    {{#link-to data-foo "posts"}}
+      Recent Posts
+    {{/link-to}}
+    {{#link-to data-foo this.dynamicPath (query-params direction="desc" showArchived=false)}}
+      Recent Posts
+    {{/link-to}}
+  `;
+
+  expect(runTest('data-test-attributes.hbs', input, options)).toMatchInlineSnapshot(`
+    "
+        <XFoo @data-foo={{true}} />
+        <XFoo @data-test-selector={{true}} />
+        <XFoo @data-test-selector={{post.id}} />
+        <XFoo @label=\\"hi\\" @data-test-selector={{true}} />
+        <XFoo data-test-foo />
+
+        <XFoo @data-foo={{true}}>
+          block
+        </XFoo>
+
+        <XFoo @data-test-selector={{true}}>
+          block
+        </XFoo>
+
+        <XFoo @data-test-selector={{post.id}}>
+          block
+        </XFoo>
+
+        <Common::AccordionComponent data-test-accordion as |accordion|>
+          block
+        </Common::AccordionComponent>
+
+        {{x-foo
+          data-foo
+          name=\\"Sophie\\"
+        }}
+
+        <LinkTo @route=\\"posts\\" data-test-foo>
+          Recent Posts
+        </LinkTo>
+        <LinkTo @route={{this.dynamicPath}} @query={{hash direction=\\"desc\\" showArchived=false}} data-test-foo>
+          Recent Posts
+        </LinkTo>
+
+        {{#link-to data-foo \\"posts\\"}}
+          Recent Posts
+        {{/link-to}}
+        {{#link-to data-foo this.dynamicPath (query-params direction=\\"desc\\" showArchived=false)}}
+          Recent Posts
+        {{/link-to}}
+      "
+  `);
+});
+
 test('deeply-nested-sub', () => {
   let input = `
     {{#some-component class=(concat foo (some-helper ted (some-dude bar (a b c)))) }}

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -172,6 +172,9 @@ test('data-test-attributes', () => {
     {{#link-to data-test-foo this.dynamicPath (query-params direction="desc" showArchived=false)}}
       Recent Posts
     {{/link-to}}
+    {{#link-to data-test-foo data-foo this.dynamicPath (query-params direction="desc" showArchived=false)}}
+      Recent Posts
+    {{/link-to}}
 
     {{x-foo
       data-foo
@@ -214,6 +217,9 @@ test('data-test-attributes', () => {
           Recent Posts
         </LinkTo>
         <LinkTo @route={{this.dynamicPath}} @query={{hash direction=\\"desc\\" showArchived=false}} data-test-foo>
+          Recent Posts
+        </LinkTo>
+        <LinkTo @route={{this.dynamicPath}} @query={{hash direction=\\"desc\\" showArchived=false}} data-test-foo data-foo>
           Recent Posts
         </LinkTo>
 

--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -154,28 +154,18 @@ test('data-test-attributes', () => {
     {{x-foo data-test-selector=post.id}}
     {{x-foo label="hi" data-test-selector=true}}
     {{x-foo data-test-foo }}
-
     {{#x-foo data-foo=true}}
       block
     {{/x-foo}}
-
     {{#x-foo data-test-selector=true}}
       block
     {{/x-foo}}
-
     {{#x-foo data-test-selector=post.id}}
       block
     {{/x-foo}}
-
     {{#common/accordion-component data-test-accordion as |accordion|}}
       block
     {{/common/accordion-component}}
-
-    {{x-foo
-      data-foo
-      name="Sophie"
-    }}
-
     {{#link-to data-test-foo "posts"}}
       Recent Posts
     {{/link-to}}
@@ -183,6 +173,16 @@ test('data-test-attributes', () => {
       Recent Posts
     {{/link-to}}
 
+    {{x-foo
+      data-foo
+      name="Sophie"
+    }}
+    {{#x-foo data-foo}}
+      block
+    {{/x-foo}}
+    {{#common/accordion-component data-accordion as |accordion|}}
+      block
+    {{/common/accordion-component}}
     {{#link-to data-foo "posts"}}
       Recent Posts
     {{/link-to}}
@@ -198,28 +198,18 @@ test('data-test-attributes', () => {
         <XFoo @data-test-selector={{post.id}} />
         <XFoo @label=\\"hi\\" @data-test-selector={{true}} />
         <XFoo data-test-foo />
-
         <XFoo @data-foo={{true}}>
           block
         </XFoo>
-
         <XFoo @data-test-selector={{true}}>
           block
         </XFoo>
-
         <XFoo @data-test-selector={{post.id}}>
           block
         </XFoo>
-
         <Common::AccordionComponent data-test-accordion as |accordion|>
           block
         </Common::AccordionComponent>
-
-        {{x-foo
-          data-foo
-          name=\\"Sophie\\"
-        }}
-
         <LinkTo @route=\\"posts\\" data-test-foo>
           Recent Posts
         </LinkTo>
@@ -227,6 +217,16 @@ test('data-test-attributes', () => {
           Recent Posts
         </LinkTo>
 
+        {{x-foo
+          data-foo
+          name=\\"Sophie\\"
+        }}
+        {{#x-foo data-foo}}
+          block
+        {{/x-foo}}
+        {{#common/accordion-component data-accordion as |accordion|}}
+          block
+        {{/common/accordion-component}}
         {{#link-to data-foo \\"posts\\"}}
           Recent Posts
         {{/link-to}}


### PR DESCRIPTION
The current codemod skips on transforming nodes with valueless attributes. This prevents a full migration for those who use libraries like [ember-test-selectors](https://github.com/simplabs/ember-test-selectors).

This PR adds the config `includeValuelessDataAttributes` so the codemod includes data attributes that are valueless.

https://github.com/ember-codemods/ember-angle-brackets-codemod/issues/237