### PR TITLE
add a note on skipping helpers when running w/o telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ $ cd my-ember-app-or-addon
 $ npx ember-angle-brackets-codemod ./path/of/files/ or ./some**/*glob.hbs
 ```
 
+**NOTE** If you are not using telemetry, you will probably need to [manually configure the codemod to at least skip any helpers](#skipping-helpers) that are invoked in the template files you are running it on.
+
 ## From
 
 ```hbs


### PR DESCRIPTION
I haven't tried this yet, but in reviewing #287 it occurred to me that I'm pretty sure you'd want to configure this to at least skip helpers when running w/o telemetry.