### PR TITLE
Add test for input-helper with action helper

### DIFF
--- a/transforms/angle-brackets/transform.test.js
+++ b/transforms/angle-brackets/transform.test.js
@@ -444,6 +444,18 @@ test('input-helper', () => {
   `);
 });
 
+test('input-helper-with-action', () => {
+  let input = `
+    {{input class='cl-input' value=(readonly param) input=(action 'paramUpdated' value='target.value')}}
+  `;
+
+  expect(runTest('input-helper.hbs', input)).toMatchInlineSnapshot(`
+    "
+    <Input class=\\"cl-input\\" @value={{readonly param}} @input={{action 'paramUpdated' value='target.value'}} />
+    "
+  `);
+});
+
 test('let', () => {
   let input = `
     {{#let (capitalize this.person.firstName) (capitalize this.person.lastName)


### PR DESCRIPTION
Add a test case showing that `{{action 'foo' value='target.foo'`` is preserved by the transform.

As discussed in the thread: https://discord.com/channels/480462759797063690/480462759797063692/1107915351829794836

> an the angle-bracket codemod + ember-template-lint and i have some regressions related to `(action 'foo' value='target.value')` being transformed without including the `value=target.value` part.
> 
> example:
> 
> ```
> <Input
> @input={{perform onInputTask value='target.value'}}
> ```
> 
> 
> becomes:
> ```
> <Input
> {{on 'input' (perform onInputTask)}}
> ```
> 
> 
> which breaks things.
> 
> Warning for anyone who tries ember-template-lint / angle-bracket-code-mod (not sure which is to blame).

I believe that the issue is actually caused by [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint) and not this codemod.

I'm opening this to follow through on a promise made to open the test. It might not be necessary to merge it since the behavior is not caused by this repo to my knowledge.